### PR TITLE
feat: Create DebugController for testing and simulation

### DIFF
--- a/config/packages/tehou.yaml
+++ b/config/packages/tehou.yaml
@@ -1,4 +1,7 @@
 tehou:
+    debug:
+        enabled: true
+        token: "DEBUG_TOKEN_CHANGE_IN_PROD"
     syslog:
         batch_size: 1000
         max_processing_time: 300 # 5 minutes max

--- a/docs/2025-08-04_07-30_DebugController_Creation.md
+++ b/docs/2025-08-04_07-30_DebugController_Creation.md
@@ -1,0 +1,85 @@
+# Rapport de Création - DebugController
+
+**Date :** 2025-08-04
+**Auteur :** Jules
+**Service :** `src/Controller/DebugController.php`
+
+## 1. Contexte
+
+Ce rapport documente la création complète du `DebugController`, un nouveau service d'API REST conçu pour faciliter les tests et le débogage de l'application TEHOU. Ce contrôleur fournit une série d'endpoints pour simuler le comportement des clients lourds et pour manipuler les données de test.
+
+## 2. Fichiers Créés et Modifiés
+
+### Fichiers Créés
+
+-   `src/Controller/DebugController.php`: Le nouveau contrôleur avec tous les endpoints de débogage.
+-   `tests/Controller/DebugControllerTest.php`: La suite de tests pour le nouveau contrôleur.
+-   `docs/2025-08-04_07-30_DebugController_Creation.md`: Ce rapport.
+
+### Fichiers Modifiés
+
+-   `src/Entity/AgentConnexion.php`: Ajout d'un champ `status` pour suivre l'état de l'agent (active, sleep, logout).
+-   `src/Service/ArchitectureService.php`: Ajout de méthodes publiques (`addAgent`, `deleteAgent`, `createTestPosition`) pour la gestion des données de test.
+-   `src/Service/PositionService.php`: Implémentation de la méthode `veilleAgent` et mise à jour des autres méthodes pour utiliser le nouveau champ `status`.
+-   `config/packages/tehou.yaml`: Ajout de la section de configuration `debug`.
+-   `src/DependencyInjection/Configuration.php`: Définition de la structure de configuration pour `tehou.debug`.
+-   `src/DependencyInjection/TehouExtension.php`: Chargement de la configuration `tehou.debug` dans le conteneur de services.
+
+## 3. Configuration Requise
+
+Pour activer le `DebugController`, la configuration suivante doit être présente dans `config/packages/tehou.yaml`:
+
+```yaml
+tehou:
+    debug:
+        enabled: true
+        token: "UN_TOKEN_SECRET_A_CHANGER"
+```
+
+-   `enabled`: Si `false`, tous les endpoints du contrôleur renverront une erreur 403.
+-   `token`: Le token secret à fournir dans l'en-tête `Authorization` en tant que Bearer token.
+
+## 4. Endpoints de l'API de Débogage
+
+Tous les endpoints nécessitent l'en-tête `Authorization: Bearer VOTRE_TOKEN`.
+
+### 4.1. Endpoints de Simulation
+
+-   `POST /api/debug/simulate-position`
+    -   **Description :** Simule une actualisation de position d'un agent.
+    -   **Body (JSON) :** `{"username": "12345", "mac": "AA:BB:CC:DD:EE:FF", "ip": "55.153.4.10"}`
+-   `POST /api/debug/simulate-logout`
+    -   **Description :** Simule la déconnexion d'un agent.
+    -   **Body (JSON) :** `{"username": "12345"}`
+-   `POST /api/debug/simulate-sleep`
+    -   **Description :** Simule la mise en veille du client d'un agent.
+    -   **Body (JSON) :** `{"username": "12345"}`
+-   `POST /api/debug/simulate-timeout`
+    -   **Description :** Force le nettoyage de toutes les positions expirées.
+    -   **Body :** Vide.
+
+### 4.2. Endpoint d'État
+
+-   `GET /api/debug/get-state`
+    -   **Description :** Retourne un état complet de l'occupation de tous les sites, étages, et services, avec des statistiques détaillées.
+    -   **Réponse :** Un objet JSON complexe décrivant toute l'architecture et l'état d'occupation.
+
+### 4.3. Endpoints de Gestion des Données de Test
+
+-   `POST /api/debug/create-test-agent`
+    -   **Description :** Crée un nouvel agent de test.
+    -   **Body (JSON) :** `{"numagent": "99999", "nom": "Test", "prenom": "Agent"}`
+-   `DELETE /api/debug/remove-test-agent/{numagent}`
+    -   **Description :** Supprime un agent de test et ses données associées.
+-   `POST /api/debug/create-test-position`
+    -   **Description :** Crée une nouvelle position de test avec une adresse MAC aléatoire.
+-   `GET /api/debug/list-test-data`
+    -   **Description :** Liste les agents et positions actuellement dans la base de données.
+
+## 5. Tests
+
+Une suite de tests a été créée pour le contrôleur. Cependant, l'exécution des tests a échoué en raison de timeouts persistants lors de l'initialisation de la base de données de test, un problème connu dans l'environnement de développement actuel. Les tests ont été écrits pour valider l'authentification et la fonctionnalité de base des endpoints et sont disponibles dans `tests/Controller/DebugControllerTest.php`.
+
+## 6. Conclusion
+
+Le `DebugController` est un outil puissant pour le développement et la maintenance de l'application TEHOU. Il fournit les fonctionnalités nécessaires pour simuler le comportement des clients et pour gérer un environnement de test stable.

--- a/src/Controller/DebugController.php
+++ b/src/Controller/DebugController.php
@@ -1,0 +1,306 @@
+<?php
+
+namespace App\Controller;
+
+use App\Service\ArchitectureService;
+use App\Service\PositionService;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Annotation\Route;
+
+#[Route('/api/debug')]
+class DebugController extends AbstractController
+{
+    public function __construct(
+        private readonly PositionService $positionService,
+        private readonly ArchitectureService $architectureService,
+        private readonly EntityManagerInterface $em,
+        #[Autowire('%tehou.debug.enabled%')] private readonly bool $debugEnabled,
+        #[Autowire('%tehou.debug.token%')] private readonly string $debugToken
+    ) {
+    }
+
+    /**
+     * Vérifie si l'utilisateur est autorisé à utiliser les endpoints de debug.
+     *
+     * @param Request $request
+     * @return JsonResponse|null
+     */
+    private function isAuthorized(Request $request): ?JsonResponse
+    {
+        if (!$this->debugEnabled) {
+            return $this->json(['message' => 'Debug mode is not enabled.'], 403);
+        }
+
+        $authHeader = $request->headers->get('Authorization');
+        if (!$authHeader) {
+            return $this->json(['message' => 'Authorization header is missing.'], 401);
+        }
+
+        $token = str_replace('Bearer ', '', $authHeader);
+        if ($token !== $this->debugToken) {
+            return $this->json(['message' => 'Invalid debug token.'], 403);
+        }
+
+        return null;
+    }
+
+    // Endpoints will be added here in the next steps.
+
+    #[Route('/simulate-position', name: 'api_debug_simulate_position', methods: ['POST'])]
+    public function simulatePosition(Request $request): JsonResponse
+    {
+        if ($authError = $this->isAuthorized($request)) {
+            return $authError;
+        }
+
+        $data = json_decode($request->getContent(), true);
+        $username = $data['username'] ?? null;
+        $mac = $data['mac'] ?? null;
+        $ip = $data['ip'] ?? null;
+        $status = $data['status'] ?? 'active';
+
+        if (!$username || !$mac || !$ip) {
+            return $this->json(['message' => 'Missing parameters: username, mac, ip are required.'], 400);
+        }
+
+        try {
+            $this->positionService->actualiserAgent($username, $ip, $mac, $status);
+            return $this->json(['status' => 'success', 'message' => "Position simulated for agent $username."]);
+        } catch (\Exception $e) {
+            return $this->json(['status' => 'error', 'message' => $e->getMessage()], 500);
+        }
+    }
+
+    #[Route('/simulate-logout', name: 'api_debug_simulate_logout', methods: ['POST'])]
+    public function simulateLogout(Request $request): JsonResponse
+    {
+        if ($authError = $this->isAuthorized($request)) {
+            return $authError;
+        }
+
+        $data = json_decode($request->getContent(), true);
+        $username = $data['username'] ?? null;
+
+        if (!$username) {
+            return $this->json(['message' => 'Missing parameter: username is required.'], 400);
+        }
+
+        $this->positionService->deconnecterAgent($username);
+
+        return $this->json(['status' => 'success', 'message' => "Logout simulated for agent $username."]);
+    }
+
+    #[Route('/simulate-sleep', name: 'api_debug_simulate_sleep', methods: ['POST'])]
+    public function simulateSleep(Request $request): JsonResponse
+    {
+        if ($authError = $this->isAuthorized($request)) {
+            return $authError;
+        }
+
+        $data = json_decode($request->getContent(), true);
+        $username = $data['username'] ?? null;
+
+        if (!$username) {
+            return $this->json(['message' => 'Missing parameter: username is required.'], 400);
+        }
+
+        $this->positionService->veilleAgent($username);
+
+        return $this->json(['status' => 'success', 'message' => "Sleep simulated for agent $username."]);
+    }
+
+    #[Route('/simulate-timeout', name: 'api_debug_simulate_timeout', methods: ['POST'])]
+    public function simulateTimeout(Request $request): JsonResponse
+    {
+        if ($authError = $this->isAuthorized($request)) {
+            return $authError;
+        }
+
+        $cleanedCount = $this->positionService->cleanExpiredPositions();
+
+        return $this->json([
+            'status' => 'success',
+            'message' => "$cleanedCount expired positions cleaned up."
+        ]);
+    }
+
+    #[Route('/get-state', name: 'api_debug_get_state', methods: ['GET'])]
+    public function getState(Request $request): JsonResponse
+    {
+        if ($authError = $this->isAuthorized($request)) {
+            return $authError;
+        }
+
+        $sites = $this->architectureService->getSites();
+        $response = ['sites' => []];
+
+        foreach ($sites as $site) {
+            $siteData = [
+                'id' => $site->getId(),
+                'nom' => $site->getNom(),
+                'etages' => [],
+            ];
+
+            $etages = $this->architectureService->getEtages($site);
+            foreach ($etages as $etage) {
+                $etageData = [
+                    'id' => $etage->getId(),
+                    'nom' => $etage->getNom(),
+                    'stats' => ['total' => 0, 'occupied' => 0, 'rate' => 0.0],
+                    'services' => [],
+                ];
+
+                $services = $this->architectureService->getServices($etage);
+                foreach ($services as $service) {
+                    $positionsInService = $this->em->getRepository(\App\Entity\Position::class)->findBy(['service' => $service]);
+                    $totalPositionsService = count($positionsInService);
+                    $occupiedPositionsService = 0;
+
+                    $serviceData = [
+                        'id' => $service->getId(),
+                        'nom' => $service->getNom(),
+                        'stats' => ['total' => $totalPositionsService, 'occupied' => 0, 'rate' => 0.0],
+                        'positions' => [],
+                    ];
+
+                    foreach ($positionsInService as $position) {
+                        $agentPosition = $this->em->getRepository(\App\Entity\AgentPosition::class)->findOneBy(['position' => $position]);
+                        $positionData = [
+                            'id' => $position->getId(),
+                            'status' => 'libre',
+                            'agent' => null,
+                        ];
+
+                        if ($agentPosition) {
+                            $occupiedPositionsService++;
+                            $positionData['status'] = 'occupee';
+                            $positionData['agent'] = [
+                                'numagent' => $agentPosition->getAgent()->getNumagent(),
+                                'nom' => $agentPosition->getAgent()->getNom(),
+                                'prenom' => $agentPosition->getAgent()->getPrenom(),
+                            ];
+                        }
+                        $serviceData['positions'][] = $positionData;
+                    }
+
+                    $serviceData['stats']['occupied'] = $occupiedPositionsService;
+                    if ($totalPositionsService > 0) {
+                        $serviceData['stats']['rate'] = round(($occupiedPositionsService / $totalPositionsService) * 100, 2);
+                    }
+
+                    $etageData['stats']['total'] += $totalPositionsService;
+                    $etageData['stats']['occupied'] += $occupiedPositionsService;
+                    $etageData['services'][] = $serviceData;
+                }
+
+                if ($etageData['stats']['total'] > 0) {
+                    $etageData['stats']['rate'] = round(($etageData['stats']['occupied'] / $etageData['stats']['total']) * 100, 2);
+                }
+                $siteData['etages'][] = $etageData;
+            }
+            $response['sites'][] = $siteData;
+        }
+
+        return $this->json($response);
+    }
+
+    #[Route('/create-test-agent', name: 'api_debug_create_test_agent', methods: ['POST'])]
+    public function createTestAgent(Request $request): JsonResponse
+    {
+        if ($authError = $this->isAuthorized($request)) {
+            return $authError;
+        }
+
+        $data = json_decode($request->getContent(), true);
+
+        if (empty($data['numagent']) || empty($data['nom']) || empty($data['prenom'])) {
+             return $this->json(['message' => 'Missing parameters: numagent, nom, prenom are required.'], 400);
+        }
+
+        // Find a random service to assign the agent to
+        $services = $this->em->getRepository(\App\Entity\Service::class)->findAll();
+        if (empty($services)) {
+            return $this->json(['message' => 'No services found in the database. Cannot create agent.'], 500);
+        }
+        $data['service_id'] = $services[array_rand($services)]->getId();
+
+
+        try {
+            $agent = $this->architectureService->addAgent($data);
+            return $this->json([
+                'status' => 'success',
+                'message' => "Test agent {$agent->getNumagent()} created.",
+                'agent' => [
+                    'numagent' => $agent->getNumagent(),
+                    'nom' => $agent->getNom(),
+                    'prenom' => $agent->getPrenom(),
+                    'service_id' => $agent->getService()->getId(),
+                ]
+            ], 201);
+        } catch (\InvalidArgumentException $e) {
+            return $this->json(['status' => 'error', 'message' => $e->getMessage()], 400);
+        } catch (\Exception $e) {
+            return $this->json(['status' => 'error', 'message' => $e->getMessage()], 500);
+        }
+    }
+
+    #[Route('/remove-test-agent/{numagent}', name: 'api_debug_remove_test_agent', methods: ['DELETE'])]
+    public function removeTestAgent(Request $request, string $numagent): JsonResponse
+    {
+        if ($authError = $this->isAuthorized($request)) {
+            return $authError;
+        }
+
+        $this->architectureService->deleteAgent($numagent);
+
+        return $this->json([
+            'status' => 'success',
+            'message' => "Agent $numagent and related data removed."
+        ]);
+    }
+
+    #[Route('/create-test-position', name: 'api_debug_create_test_position', methods: ['POST'])]
+    public function createTestPosition(Request $request): JsonResponse
+    {
+        if ($authError = $this->isAuthorized($request)) {
+            return $authError;
+        }
+
+        try {
+            $position = $this->architectureService->createTestPosition();
+            return $this->json([
+                'status' => 'success',
+                'message' => 'Test position created.',
+                'position' => [
+                    'id' => $position->getId(),
+                    'mac' => $position->getMac(),
+                    'prise' => $position->getPrise(),
+                    'etage' => $position->getEtage()->getNom(),
+                    'service' => $position->getService()->getNom(),
+                ]
+            ], 201);
+        } catch (\RuntimeException $e) {
+            return $this->json(['status' => 'error', 'message' => $e->getMessage()], 500);
+        }
+    }
+
+    #[Route('/list-test-data', name: 'api_debug_list_test_data', methods: ['GET'])]
+    public function listTestData(Request $request): JsonResponse
+    {
+        if ($authError = $this->isAuthorized($request)) {
+            return $authError;
+        }
+
+        $agents = $this->em->getRepository(\App\Entity\Agent::class)->findAll();
+        $positions = $this->em->getRepository(\App\Entity\Position::class)->findAll();
+
+        return $this->json([
+            'agents' => array_map(fn($a) => ['numagent' => $a->getNumagent(), 'nom' => $a->getNom()], $agents),
+            'positions' => array_map(fn($p) => ['id' => $p->getId(), 'mac' => $p->getMac()], $positions),
+        ]);
+    }
+}

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -13,6 +13,12 @@ class Configuration implements ConfigurationInterface
 
         $treeBuilder->getRootNode()
             ->children()
+                ->arrayNode('debug')
+                    ->children()
+                        ->booleanNode('enabled')->defaultFalse()->end()
+                        ->scalarNode('token')->defaultValue('')->end()
+                    ->end()
+                ->end()
                 ->arrayNode('syslog')
                     ->children()
                         ->integerNode('batch_size')->defaultValue(1000)->end()

--- a/src/DependencyInjection/TehouExtension.php
+++ b/src/DependencyInjection/TehouExtension.php
@@ -17,6 +17,11 @@ class TehouExtension extends Extension
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);
 
+        // Set debug parameters
+        $container->setParameter('tehou.debug.enabled', $config['debug']['enabled']);
+        $container->setParameter('tehou.debug.token', $config['debug']['token']);
+
+        // Set syslog parameters
         $container->setParameter('tehou.syslog.batch_size', $config['syslog']['batch_size']);
         $container->setParameter('tehou.syslog.max_processing_time', $config['syslog']['max_processing_time']);
         $container->setParameter('tehou.syslog.max_errors', $config['syslog']['max_errors']);

--- a/src/Entity/AgentConnexion.php
+++ b/src/Entity/AgentConnexion.php
@@ -34,6 +34,9 @@ class AgentConnexion
     #[ORM\Column(type: Types::DATETIME_MUTABLE, options: ['default' => 'CURRENT_TIMESTAMP'])]
     private ?\DateTimeInterface $dateactualisation = null;
 
+    #[ORM\Column(length: 10, nullable: true)]
+    private ?string $status = null;
+
     public function getId(): ?int
     {
         return $this->id;
@@ -107,6 +110,18 @@ class AgentConnexion
     public function setDateactualisation(\DateTimeInterface $dateactualisation): static
     {
         $this->dateactualisation = $dateactualisation;
+
+        return $this;
+    }
+
+    public function getStatus(): ?string
+    {
+        return $this->status;
+    }
+
+    public function setStatus(?string $status): static
+    {
+        $this->status = $status;
 
         return $this;
     }

--- a/tests/Controller/DebugControllerTest.php
+++ b/tests/Controller/DebugControllerTest.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace App\Tests\Controller;
+
+use App\Service\ArchitectureService;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+class DebugControllerTest extends WebTestCase
+{
+    private $client;
+    private static $testToken = 'DEBUG_TOKEN_CHANGE_IN_PROD';
+    private static $testAgentNum = '99999';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->client = static::createClient();
+
+        // Ensure the database is initialized
+        $architectureService = static::getContainer()->get(ArchitectureService::class);
+        $architectureService->initialiser();
+    }
+
+    public function testEndpointsAreProtected()
+    {
+        $this->client->request('GET', '/api/debug/get-state');
+        $this->assertResponseStatusCodeSame(401, 'Request without token should be unauthorized.');
+
+        $this->client->request('GET', '/api/debug/get-state', [], [], ['HTTP_Authorization' => 'Bearer INVALID_TOKEN']);
+        $this->assertResponseStatusCodeSame(403, 'Request with invalid token should be forbidden.');
+    }
+
+    public function testCreateAndRemoveTestAgent()
+    {
+        // First, remove the agent to ensure a clean state, in case a previous test failed.
+        $this->client->request(
+            'DELETE',
+            '/api/debug/remove-test-agent/' . self::$testAgentNum,
+            [],
+            [],
+            ['HTTP_Authorization' => 'Bearer ' . self::$testToken]
+        );
+        $this->assertResponseStatusCodeSame(200);
+
+
+        // Then, create the agent
+        $this->client->request(
+            'POST',
+            '/api/debug/create-test-agent',
+            [],
+            [],
+            [
+                'HTTP_Authorization' => 'Bearer ' . self::$testToken,
+                'CONTENT_TYPE' => 'application/json'
+            ],
+            json_encode(['numagent' => self::$testAgentNum, 'nom' => 'Test', 'prenom' => 'Agent'])
+        );
+
+        $this->assertResponseStatusCodeSame(201);
+        $response = json_decode($this->client->getResponse()->getContent(), true);
+        $this->assertEquals('success', $response['status']);
+        $this->assertEquals(self::$testAgentNum, $response['agent']['numagent']);
+
+        // Finally, remove the agent
+        $this->client->request(
+            'DELETE',
+            '/api/debug/remove-test-agent/' . self::$testAgentNum,
+            [],
+            [],
+            ['HTTP_Authorization' => 'Bearer ' . self::$testToken]
+        );
+
+        $this->assertResponseStatusCodeSame(200);
+        $response = json_decode($this->client->getResponse()->getContent(), true);
+        $this->assertEquals('success', $response['status']);
+    }
+
+    public function testSimulatePosition()
+    {
+        // Find an existing agent from the initialized data
+        $entityManager = static::getContainer()->get('doctrine.orm.entity_manager');
+        $agent = $entityManager->getRepository(\App\Entity\Agent::class)->findOneBy([]);
+        $this->assertNotNull($agent, "No agent found in the database to run the test.");
+
+        $this->client->request(
+            'POST',
+            '/api/debug/simulate-position',
+            [],
+            [],
+            [
+                'HTTP_Authorization' => 'Bearer ' . self::$testToken,
+                'CONTENT_TYPE' => 'application/json'
+            ],
+            json_encode([
+                'username' => $agent->getNumagent(),
+                'mac' => '00:11:22:33:44:55',
+                'ip' => '55.153.4.10' // Site IP from Cahier Technique
+            ])
+        );
+
+        $this->assertResponseStatusCodeSame(200);
+        $response = json_decode($this->client->getResponse()->getContent(), true);
+        $this->assertEquals('success', $response['status']);
+    }
+}


### PR DESCRIPTION
This commit introduces a new DebugController to facilitate testing and simulation of the TEHOU application.

The controller provides a set of REST API endpoints under `/api/debug` to:
- Simulate client actions: position updates, logout, sleep, and connection timeout.
- Get a comprehensive real-time state of office occupation.
- Manage test data: create and remove test agents and positions.

Access to these endpoints is protected by a token and must be explicitly enabled in the configuration.

Changes include:
- Creation of `src/Controller/DebugController.php`.
- Addition of a `debug` section to the application's configuration (`tehou.yaml`) and corresponding updates in `DependencyInjection`.
- Addition of a `status` field to the `AgentConnexion` entity to track agent state.
- Update of `PositionService` to handle the new status and implement the sleep logic.
- Extension of `ArchitectureService` with public methods to manage test agents and positions.
- Creation of a unit/integration test suite for the controller.
- Addition of a report documenting the new feature.